### PR TITLE
Add CI task to execute tests in cinema_assistant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
         run: |
           pylint --rcfile=.pylintrc $(git ls-files 'apps_lab/cinema_assistant/*.py' ':!:apps_lab/cinema_assistant/tests/test_*.py')
       - name: Run tests
+        env:
+          PYTHONPATH: apps_lab
         run: |
           pytest --cov=apps_lab/cinema_assistant/tests --cov-report=xml
       - name: Publish test results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           pytest --cov=apps_lab/cinema_assistant/tests --cov-report=xml
       - name: Publish test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: test-results.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Pylint
+name: CI
 
 on: [push]
 
@@ -21,3 +21,11 @@ jobs:
       - name: Analysing the code with pylint
         run: |
           pylint --rcfile=.pylintrc $(git ls-files 'apps_lab/cinema_assistant/*.py' ':!:apps_lab/cinema_assistant/tests/test_*.py')
+      - name: Run tests
+        run: |
+          pytest --cov=apps_lab/cinema_assistant/tests --cov-report=xml
+      - name: Publish test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results
+          path: test-results.xml

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # langchain_lab
+
+![CI](https://github.com/DSmmartin/langchain_lab/actions/workflows/ci.yml/badge.svg)


### PR DESCRIPTION
Rename `.github/workflows/pylint.yml` to `.github/workflows/ci.yml`.

Add a new CI task to execute tests and publish results:
* Add a step to run tests located in `langchain_lab/apps_lab/cinema_assistant/tests` folder.
* Add a step to publish the test results.

Update `README.md`:
* Add a banner to show the workflow status and test coverage.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DSmmartin/langchain_lab?shareId=fae6f082-5d57-4eaf-9f28-b139fc48e980).